### PR TITLE
Fix sending commands

### DIFF
--- a/lib/mqttCloud.js
+++ b/lib/mqttCloud.js
@@ -166,8 +166,8 @@ mqttCloud.prototype.connectMqtt = function () {
 
 
 mqttCloud.prototype.sendMessage = function (message) {
-    var topicIn = this.mqtt_topic_prefix + "/" + this.macAddress + '/commandIn';
-    this.adapter.log.debug('Sending Message: ' + message);
+    var topicIn = "PRM100/" + this.macAddress + '/commandIn';
+    this.adapter.log.debug('Sending Message: ' + message + ' with topic ' + topicIn);
     //var sends = '{"cmd":3}';
     this.device.publish(topicIn, message);
 };

--- a/lib/mqttCloud.js
+++ b/lib/mqttCloud.js
@@ -166,10 +166,9 @@ mqttCloud.prototype.connectMqtt = function () {
 
 
 mqttCloud.prototype.sendMessage = function (message) {
-    var topicIn = "PRM100/" + this.macAddress + '/commandIn';
-    this.adapter.log.debug('Sending Message: ' + message + ' with topic ' + topicIn);
+    this.adapter.log.debug('Sending Message: ' + message + ' with topic ' + self.mqtt_command_in);
     //var sends = '{"cmd":3}';
-    this.device.publish(topicIn, message);
+    this.device.publish(self.mqtt_command_in, message);
 };
 
 /** New MQTT message received */

--- a/lib/mqttCloud.js
+++ b/lib/mqttCloud.js
@@ -166,9 +166,9 @@ mqttCloud.prototype.connectMqtt = function () {
 
 
 mqttCloud.prototype.sendMessage = function (message) {
-    this.adapter.log.debug('Sending Message: ' + message + ' with topic ' + self.mqtt_command_in);
+    this.adapter.log.debug('Sending Message: ' + message + ' with topic ' + this.mqtt_command_in);
     //var sends = '{"cmd":3}';
-    this.device.publish(self.mqtt_command_in, message);
+    this.device.publish(this.mqtt_command_in, message);
 };
 
 /** New MQTT message received */


### PR DESCRIPTION
this.mqtt_topic_prefix is not defined which results in messages not being sent to the right topic. This pull request fixes the issue.